### PR TITLE
fix: Bump rimfrost-framework-regel version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>se.fk.rimfrost.framework.regel</groupId>
       <artifactId>rimfrost-framework-regel</artifactId>
-      <version>0.1.6</version>
+      <version>0.1.10</version>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -29,3 +29,6 @@ lagrum:
   paragraf: 7
   stycke: 2
   punkt: 3
+
+utokadUppgiftsbeskrivning:
+  beskrivning: "Maskinell kontroll som kollar om kunden är folkbokförd i sverige samt kollar om personen har en arbetsgivare"

--- a/src/test/resources/config-test.yaml
+++ b/src/test/resources/config-test.yaml
@@ -29,3 +29,6 @@ lagrum:
   paragraf: 5
   stycke: 1
   punkt: 4
+
+utokadUppgiftsbeskrivning:
+  beskrivning: "TestUtokadUppgiftsbeskrivning"


### PR DESCRIPTION
This commit bumps rimfrost-framework-regel version in order to include a fix to config.yaml discovery handling.