### PR TITLE
Bump rimfrost-framework-regel-maskinell to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,33 +63,21 @@
     <dependency>
       <groupId>se.fk.rimfrost.framework.regel</groupId>
       <artifactId>rimfrost-framework-regel</artifactId>
+      <version>1.0.8</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>se.fk.rimfrost.framework.regel.maskinell</groupId>
+      <artifactId>rimfrost-framework-regel-maskinell</artifactId>
+      <version>1.0.7</version>
+    </dependency>
+    <dependency>
+      <groupId>se.fk.rimfrost.framework.regel.maskinell</groupId>
+      <artifactId>rimfrost-framework-regel-maskinell</artifactId>
       <version>1.0.7</version>
       <classifier>tests</classifier>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>se.fk.rimfrost.framework.regel.maskinell</groupId>
-      <artifactId>rimfrost-framework-regel-maskinell</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>se.fk.rimfrost.framework.regel.maskinell</groupId>
-      <artifactId>rimfrost-framework-regel-maskinell</artifactId>
-      <version>1.0.0</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!--
-      TODO: Replace this dependency with a suitable implementation of rimfrost-framework-uppgift-status-provider-interface that returns the correct referensdata ids
-
-      This dependency should be replaced with a dependency on a different implementation of rimfrost-framework-uppgift-status-provider-interface
-      that returns the referensdata ids relevant to the deployment environment of the rule. See https://github.com/Forsakringskassan/rimfrost-framework-uppgift-status-provider
-      for a description of the included provider.
-      -->
-      <groupId>se.fk.rimfrost.framework.uppgiftstatusprovider</groupId>
-      <artifactId>rimfrost-framework-uppgift-status-provider</artifactId>
-      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>

--- a/src/main/java/se/fk/github/regeltemplate/logic/RegelTemplateService.java
+++ b/src/main/java/se/fk/github/regeltemplate/logic/RegelTemplateService.java
@@ -1,20 +1,20 @@
 package se.fk.github.regeltemplate.logic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import se.fk.rimfrost.framework.handlaggning.model.ImmutableHandlaggningUpdate;
+import se.fk.rimfrost.framework.handlaggning.model.ImmutableUppgift;
 import se.fk.rimfrost.framework.handlaggning.model.ImmutableUnderlag;
 import se.fk.rimfrost.framework.regel.Utfall;
-import se.fk.rimfrost.framework.handlaggning.model.ImmutableUppgift;
 import se.fk.rimfrost.framework.regel.maskinell.logic.RegelMaskinellServiceInterface;
-import se.fk.rimfrost.framework.regel.maskinell.logic.dto.ImmutableRegelMaskinellResult;
+import se.fk.rimfrost.framework.regel.maskinell.logic.dto.ImmutableRegelMaskinellSuccessResult;
 import se.fk.rimfrost.framework.regel.maskinell.logic.dto.RegelMaskinellRequest;
 import se.fk.rimfrost.framework.regel.maskinell.logic.dto.RegelMaskinellResult;
-import se.fk.rimfrost.framework.uppgiftstatusprovider.UppgiftStatusProvider;
 
 @ApplicationScoped
 public class RegelTemplateService implements RegelMaskinellServiceInterface
@@ -24,9 +24,7 @@ public class RegelTemplateService implements RegelMaskinellServiceInterface
    @Inject
    ObjectMapper objectMapper;
 
-   @Inject
-   UppgiftStatusProvider uppgiftStatusProvider;
-
+   @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "False positive for uppgiftStatus field. UppgiftStatus field is marked as nullable.")
    @Override
    public RegelMaskinellResult processRegel(RegelMaskinellRequest regelRequest)
    {
@@ -37,7 +35,7 @@ public class RegelTemplateService implements RegelMaskinellServiceInterface
       var uppgift = ImmutableUppgift.builder()
             .from(regelRequest.uppgift())
             .utfordTs(OffsetDateTime.now())
-            .uppgiftStatus(uppgiftStatusProvider.getAvslutadId())
+            .uppgiftStatus(null)
             .build();
 
       // TODO replace with underlag of the service
@@ -66,7 +64,7 @@ public class RegelTemplateService implements RegelMaskinellServiceInterface
             .underlag(underlag)
             .build();
 
-      return ImmutableRegelMaskinellResult.builder()
+      return ImmutableRegelMaskinellSuccessResult.builder()
             .handlaggningUpdate(handlaggningUpdate)
             .utfall(Utfall.JA)
             .build();

--- a/src/main/java/se/fk/github/regeltemplate/logic/RegelTemplateService.java
+++ b/src/main/java/se/fk/github/regeltemplate/logic/RegelTemplateService.java
@@ -1,7 +1,6 @@
 package se.fk.github.regeltemplate.logic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
@@ -24,7 +23,6 @@ public class RegelTemplateService implements RegelMaskinellServiceInterface
    @Inject
    ObjectMapper objectMapper;
 
-   @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "False positive for uppgiftStatus field. UppgiftStatus field is marked as nullable.")
    @Override
    public RegelMaskinellResult processRegel(RegelMaskinellRequest regelRequest)
    {
@@ -35,7 +33,6 @@ public class RegelTemplateService implements RegelMaskinellServiceInterface
       var uppgift = ImmutableUppgift.builder()
             .from(regelRequest.uppgift())
             .utfordTs(OffsetDateTime.now())
-            .uppgiftStatus(null)
             .build();
 
       // TODO replace with underlag of the service

--- a/src/test/java/se/fk/github/regeltemplate/RegelTemplateProcessRegelTest.java
+++ b/src/test/java/se/fk/github/regeltemplate/RegelTemplateProcessRegelTest.java
@@ -5,9 +5,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import jakarta.inject.Inject;
 import se.fk.github.regeltemplate.logic.RegelTemplateService;
-import se.fk.rimfrost.framework.regel.*;
+import se.fk.rimfrost.framework.regel.Utfall;
 import se.fk.rimfrost.framework.regel.maskinell.base.AbstractRegelMaskinellTest;
+import se.fk.rimfrost.framework.regel.maskinell.logic.dto.RegelMaskinellSuccessResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static se.fk.github.regeltemplate.RegelTemplateTestData.newRegelMaskinellRequest;
 
 @QuarkusTest
@@ -28,7 +30,8 @@ public class RegelTemplateProcessRegelTest extends AbstractRegelMaskinellTest
 
       var result = regelService.processRegel(request);
 
-      assertEquals(Utfall.JA, result.utfall());
+      assertInstanceOf(RegelMaskinellSuccessResult.class, result);
+      assertEquals(Utfall.JA, ((RegelMaskinellSuccessResult) result).utfall());
    }
 
    // TODO: Add more tests as needed


### PR DESCRIPTION
Bumps rimfrost-framework-regel-maskinell to 1.0.7 and rimfrost-framework-regel (tests) to 1.0.8.

The new framework version removed UppgiftStatusProvider from the maskinell framework since machine rules have no OUL status. This PR adapts the template accordingly:

- Removes the dependency on the archived rimfrost-framework-uppgift-status-provider
- Replaces UppgiftStatusProvider injection in RegelTemplateService with uppgiftStatus(null)
- Updates ImmutableRegelMaskinellResult → ImmutableRegelMaskinellSuccessResult following the renamed API
- Updates test to cast result to RegelMaskinellSuccessResult before asserting utfall