### PR TITLE
fix: remove unused uppgift-status-provider index-dependency

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,9 +8,6 @@ kafka.source=RegelMaskinell
 quarkus.index-dependency.regel-maskinell.group-id=se.fk.rimfrost.framework.regel.maskinell
 quarkus.index-dependency.regel-maskinell.artifact-id=rimfrost-framework-regel-maskinell
 
-quarkus.index-dependency.rimfrost-framework-uppgift-status-provider.group-id=se.fk.rimfrost.framework.uppgiftstatusprovider
-quarkus.index-dependency.rimfrost-framework-uppgift-status-provider.artifact-id=rimfrost-framework-uppgift-status-provider
-
 #Incoming
 # TODO: Change request topic to something unique for the rule
 mp.messaging.incoming.regel-requests.topic=regel-maskinell-requests


### PR DESCRIPTION
## Summary

- Removes the `quarkus.index-dependency` entries for `rimfrost-framework-uppgift-status-provider` from `application.properties`
