### PR TITLE
fix: clarify unused config fields for maskinella regler

### DIFF
--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -2,7 +2,8 @@
 uppgift:
   id: 7028893f-c625-42e1-ab58-5891c0d6834e
   version: 1
-  path: /regel/maskinell
+  # Används inte av maskinella regler — kan utelämnas
+  # path: /regel/manuell-exempel
   aktivitet: "Bedöma rätten till"
 
 specifikation:
@@ -31,5 +32,4 @@ lagrum:
   stycke: 2
   punkt: 3
 
-utokadUppgiftsbeskrivning:
-  beskrivning: "Maskinell kontroll som ..."
+# utokadUppgiftsbeskrivning används inte av maskinella regler


### PR DESCRIPTION
Comments out `path` and `utokadUppgiftsbeskrivning` in `config.yaml` with
explanatory notes that these fields are not used by maskinella regler and can
be omitted. Replaces a misleading example value (`/regel/maskinell`) with a
commented-out manuell example to avoid confusion.