### PR TITLE
Add config.yaml validation to CI and bump framework to 1.2.3

### DIFF
--- a/.github/workflows/maven-ci.yaml
+++ b/.github/workflows/maven-ci.yaml
@@ -8,3 +8,8 @@ jobs:
     secrets:
       PACKAGES_RW_ACTOR: ${{ secrets.PACKAGES_RW_ACTOR }}
       PACKAGES_RW_TOKEN: ${{ secrets.PACKAGES_RW_TOKEN }}
+
+  validate-config:
+    uses: Forsakringskassan/rimfrost-framework-regel/.github/workflows/validate-config.yaml@1.2.3
+    with:
+      framework-ref: '1.2.3'

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>se.fk.rimfrost.framework.regel</groupId>
       <artifactId>rimfrost-framework-regel</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Adds a `validate-config` job to the CI workflow that reuses the shared `validate-config.yaml` workflow from `rimfrost-framework-regel` at tag `1.2.3`. This ensures `config.yaml` is validated on every push without manual intervention.

Also bumps the `rimfrost-framework-regel` test dependency from `1.2.1` to `1.2.3` to align with the workflow reference.